### PR TITLE
fix: build fail

### DIFF
--- a/app/src/pages/auth/near.tsx
+++ b/app/src/pages/auth/near.tsx
@@ -17,6 +17,7 @@ export default function Near() {
           network={nodeConfig.network as NetworkId}
         >
           <NearLogin
+            networkId={nodeConfig.network as NetworkId}
             contextId={nodeConfig.contextId}
             rpcBaseUrl={nodeConfig.nodeServerUrl}
             successRedirect={() => router.push('/feed')}


### PR DESCRIPTION
# fix: build fail

## Summary:
Build failing because of sdk bump and component props were changes in later versions.