### PR TITLE
feat: refresh JWT components and logic update

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@calimero-is-near/calimero-p2p-sdk": "0.0.37",
+    "@calimero-is-near/calimero-p2p-sdk": "0.0.38",
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
     "@libp2p/interface": "^1.1.4",

--- a/app/src/api/dataSource/ClientApiDataSource.ts
+++ b/app/src/api/dataSource/ClientApiDataSource.ts
@@ -11,9 +11,12 @@ import { Comment, JsonWebToken, Post } from '../../types/types';
 import {
   JsonRpcClient,
   RequestConfig,
+  getNewJwtToken,
+  getRefreshToken
 } from '@calimero-is-near/calimero-p2p-sdk';
 import { AxiosHeader, createJwtHeader } from '../../crypto/crypto';
 import { getAppEndpointKey, getJWTObject } from '../../utils/storage';
+import { getNodeUrl } from '../../utils/node';
 
 export function getJsonRpcClient() {
   return new JsonRpcClient(
@@ -26,6 +29,7 @@ export class ClientApiDataSource implements ClientApi {
   async fetchFeed(params: FeedRequest): ApiResponse<Post[]> {
     const jwtObject: JsonWebToken = getJWTObject();
     const headers: AxiosHeader = createJwtHeader();
+    const refreshToken = getRefreshToken();
     if (!jwtObject) {
       return {
         error: { message: 'Failed to get JWT token', code: 500 },
@@ -50,6 +54,13 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
+    // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
+    if (response.error?.inner?.response?.data === "Token not valid.") {
+      await getNewJwtToken({refreshToken, getNodeUrl});
+      return {
+        error: { message: 'Your session expired, but we have refreshed it. Please try again.', code: 500 }
+      };
+    }
 
     return {
       data: response.result?.output ?? [],
@@ -60,6 +71,7 @@ export class ClientApiDataSource implements ClientApi {
   async fetchPost(params: PostRequest): ApiResponse<Post> {
     const jwtObject: JsonWebToken = getJWTObject();
     const headers: AxiosHeader = createJwtHeader();
+    const refreshToken = getRefreshToken();
     if (!jwtObject) {
       return {
         error: { message: 'Failed to get JWT token', code: 500 },
@@ -84,6 +96,14 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
+    // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
+    if (response.error?.inner?.response?.data === "Token not valid.") {
+      await getNewJwtToken({refreshToken, getNodeUrl});
+      return {
+        error: { message: 'Your session expired, but we have refreshed it. Please try again.', code: 500 }
+      };
+    }
+
     return {
       data: response?.result?.output,
       error: null,
@@ -93,6 +113,7 @@ export class ClientApiDataSource implements ClientApi {
   async createPost(params: CreatePostRequest): ApiResponse<Post> {
     const jwtObject: JsonWebToken = getJWTObject();
     const headers: AxiosHeader = createJwtHeader();
+    const refreshToken = getRefreshToken();
     if (!jwtObject) {
       return {
         error: { message: 'Failed to get JWT token', code: 500 },
@@ -117,6 +138,14 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
+    // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
+    if (response.error?.inner?.response?.data === "Token not valid.") {
+      await getNewJwtToken({refreshToken, getNodeUrl});
+      return {
+        error: { message: 'Your session expired, but we have refreshed it. Please try again.', code: 500 }
+      };
+    }
+
     return {
       data: response?.result?.output,
       error: null,
@@ -126,6 +155,7 @@ export class ClientApiDataSource implements ClientApi {
   async createComment(params: CreateCommentRequest): ApiResponse<Comment> {
     const jwtObject: JsonWebToken = getJWTObject();
     const headers: AxiosHeader = createJwtHeader();
+    const refreshToken = getRefreshToken();
     if (!jwtObject) {
       return {
         error: { message: 'Failed to get JWT token', code: 500 },
@@ -153,6 +183,14 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
+    // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
+    if (response.error?.inner?.response?.data === "Token not valid.") {
+      await getNewJwtToken({refreshToken, getNodeUrl});
+      return {
+        error: { message: 'Your session expired, but we have refreshed it. Please try again.', code: 500 }
+      };
+    }
+
     return {
       data: response?.result?.output,
       error: null,

--- a/app/src/api/dataSource/ClientApiDataSource.ts
+++ b/app/src/api/dataSource/ClientApiDataSource.ts
@@ -11,8 +11,8 @@ import { Comment, JsonWebToken, Post } from '../../types/types';
 import {
   JsonRpcClient,
   RequestConfig,
-  getNewJwtToken,
-  getRefreshToken,
+  RpcError,
+  handleRpcError,
 } from '@calimero-is-near/calimero-p2p-sdk';
 import { AxiosHeader, createJwtHeader } from '../../crypto/crypto';
 import { getAppEndpointKey, getJWTObject } from '../../utils/storage';
@@ -29,7 +29,6 @@ export class ClientApiDataSource implements ClientApi {
   async fetchFeed(params: FeedRequest): ApiResponse<Post[]> {
     const jwtObject: JsonWebToken = getJWTObject();
     const headers: AxiosHeader = createJwtHeader();
-    const refreshToken = getRefreshToken();
     if (!jwtObject) {
       return {
         error: { message: 'Failed to get JWT token', code: 500 },
@@ -54,15 +53,10 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
-    // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
-    if (response.error?.inner?.response?.data === 'Token not valid.') {
-      await getNewJwtToken({ refreshToken, getNodeUrl });
+    const error: RpcError | null = response?.error ?? null;
+    if (error && error.code) {
       return {
-        error: {
-          message:
-            'Your session expired, but we have refreshed it. Please try again.',
-          code: 500,
-        },
+        error: await handleRpcError(error, getNodeUrl),
       };
     }
 
@@ -75,7 +69,6 @@ export class ClientApiDataSource implements ClientApi {
   async fetchPost(params: PostRequest): ApiResponse<Post> {
     const jwtObject: JsonWebToken = getJWTObject();
     const headers: AxiosHeader = createJwtHeader();
-    const refreshToken = getRefreshToken();
     if (!jwtObject) {
       return {
         error: { message: 'Failed to get JWT token', code: 500 },
@@ -100,15 +93,10 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
-    // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
-    if (response.error?.inner?.response?.data === 'Token not valid.') {
-      await getNewJwtToken({ refreshToken, getNodeUrl });
+    const error: RpcError | null = response?.error ?? null;
+    if (error && error.code) {
       return {
-        error: {
-          message:
-            'Your session expired, but we have refreshed it. Please try again.',
-          code: 500,
-        },
+        error: await handleRpcError(error, getNodeUrl),
       };
     }
 
@@ -121,7 +109,6 @@ export class ClientApiDataSource implements ClientApi {
   async createPost(params: CreatePostRequest): ApiResponse<Post> {
     const jwtObject: JsonWebToken = getJWTObject();
     const headers: AxiosHeader = createJwtHeader();
-    const refreshToken = getRefreshToken();
     if (!jwtObject) {
       return {
         error: { message: 'Failed to get JWT token', code: 500 },
@@ -146,15 +133,10 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
-    // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
-    if (response.error?.inner?.response?.data === 'Token not valid.') {
-      await getNewJwtToken({ refreshToken, getNodeUrl });
+    const error: RpcError | null = response?.error ?? null;
+    if (error && error.code) {
       return {
-        error: {
-          message:
-            'Your session expired, but we have refreshed it. Please try again.',
-          code: 500,
-        },
+        error: await handleRpcError(error, getNodeUrl),
       };
     }
 
@@ -167,7 +149,6 @@ export class ClientApiDataSource implements ClientApi {
   async createComment(params: CreateCommentRequest): ApiResponse<Comment> {
     const jwtObject: JsonWebToken = getJWTObject();
     const headers: AxiosHeader = createJwtHeader();
-    const refreshToken = getRefreshToken();
     if (!jwtObject) {
       return {
         error: { message: 'Failed to get JWT token', code: 500 },
@@ -195,15 +176,10 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
-    // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
-    if (response.error?.inner?.response?.data === 'Token not valid.') {
-      await getNewJwtToken({ refreshToken, getNodeUrl });
+    const error: RpcError | null = response?.error ?? null;
+    if (error && error.code) {
       return {
-        error: {
-          message:
-            'Your session expired, but we have refreshed it. Please try again.',
-          code: 500,
-        },
+        error: await handleRpcError(error, getNodeUrl),
       };
     }
 

--- a/app/src/api/dataSource/ClientApiDataSource.ts
+++ b/app/src/api/dataSource/ClientApiDataSource.ts
@@ -64,6 +64,10 @@ export class ClientApiDataSource implements ClientApi {
     );
     const rpcError: RpcError | null = response?.error ?? null;
     if (rpcError && rpcError.code) {
+      const response = await handleRpcError(rpcError, getNodeUrl);
+      if (response.code === 403) {
+       return await this.fetchFeed(params);
+      }
       return {
         error: await handleRpcError(rpcError, getNodeUrl),
       };
@@ -92,6 +96,10 @@ export class ClientApiDataSource implements ClientApi {
     );
     const rpcError: RpcError | null = response?.error ?? null;
     if (rpcError && rpcError.code) {
+      const response = await handleRpcError(rpcError, getNodeUrl);
+      if (response.code === 403) {
+        return await this.fetchPost(params);
+      }
       return {
         error: await handleRpcError(rpcError, getNodeUrl),
       };
@@ -120,6 +128,10 @@ export class ClientApiDataSource implements ClientApi {
     );
     const rpcError: RpcError | null = response?.error ?? null;
     if (rpcError && rpcError.code) {
+      const response = await handleRpcError(rpcError, getNodeUrl);
+      if (response.code === 403) {
+        return await this.createPost(params);
+      }
       return {
         error: await handleRpcError(rpcError, getNodeUrl),
       };
@@ -151,6 +163,10 @@ export class ClientApiDataSource implements ClientApi {
     );
     const rpcError: RpcError | null = response?.error ?? null;
     if (rpcError && rpcError.code) {
+      const response = await handleRpcError(rpcError, getNodeUrl);
+      if (response.code === 403) {
+        return await this.createComment(params);
+      }
       return {
         error: await handleRpcError(rpcError, getNodeUrl),
       };

--- a/app/src/api/dataSource/ClientApiDataSource.ts
+++ b/app/src/api/dataSource/ClientApiDataSource.ts
@@ -66,7 +66,7 @@ export class ClientApiDataSource implements ClientApi {
     if (rpcError && rpcError.code) {
       const response = await handleRpcError(rpcError, getNodeUrl);
       if (response.code === 403) {
-       return await this.fetchFeed(params);
+        return await this.fetchFeed(params);
       }
       return {
         error: await handleRpcError(rpcError, getNodeUrl),

--- a/app/src/api/dataSource/ClientApiDataSource.ts
+++ b/app/src/api/dataSource/ClientApiDataSource.ts
@@ -12,7 +12,7 @@ import {
   JsonRpcClient,
   RequestConfig,
   getNewJwtToken,
-  getRefreshToken
+  getRefreshToken,
 } from '@calimero-is-near/calimero-p2p-sdk';
 import { AxiosHeader, createJwtHeader } from '../../crypto/crypto';
 import { getAppEndpointKey, getJWTObject } from '../../utils/storage';
@@ -55,10 +55,14 @@ export class ClientApiDataSource implements ClientApi {
       config,
     );
     // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
-    if (response.error?.inner?.response?.data === "Token not valid.") {
-      await getNewJwtToken({refreshToken, getNodeUrl});
+    if (response.error?.inner?.response?.data === 'Token not valid.') {
+      await getNewJwtToken({ refreshToken, getNodeUrl });
       return {
-        error: { message: 'Your session expired, but we have refreshed it. Please try again.', code: 500 }
+        error: {
+          message:
+            'Your session expired, but we have refreshed it. Please try again.',
+          code: 500,
+        },
       };
     }
 
@@ -97,10 +101,14 @@ export class ClientApiDataSource implements ClientApi {
       config,
     );
     // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
-    if (response.error?.inner?.response?.data === "Token not valid.") {
-      await getNewJwtToken({refreshToken, getNodeUrl});
+    if (response.error?.inner?.response?.data === 'Token not valid.') {
+      await getNewJwtToken({ refreshToken, getNodeUrl });
       return {
-        error: { message: 'Your session expired, but we have refreshed it. Please try again.', code: 500 }
+        error: {
+          message:
+            'Your session expired, but we have refreshed it. Please try again.',
+          code: 500,
+        },
       };
     }
 
@@ -139,10 +147,14 @@ export class ClientApiDataSource implements ClientApi {
       config,
     );
     // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
-    if (response.error?.inner?.response?.data === "Token not valid.") {
-      await getNewJwtToken({refreshToken, getNodeUrl});
+    if (response.error?.inner?.response?.data === 'Token not valid.') {
+      await getNewJwtToken({ refreshToken, getNodeUrl });
       return {
-        error: { message: 'Your session expired, but we have refreshed it. Please try again.', code: 500 }
+        error: {
+          message:
+            'Your session expired, but we have refreshed it. Please try again.',
+          code: 500,
+        },
       };
     }
 
@@ -184,10 +196,14 @@ export class ClientApiDataSource implements ClientApi {
       config,
     );
     // @ts-expect-error: Property 'inner' does not exist on type 'RpcError'
-    if (response.error?.inner?.response?.data === "Token not valid.") {
-      await getNewJwtToken({refreshToken, getNodeUrl});
+    if (response.error?.inner?.response?.data === 'Token not valid.') {
+      await getNewJwtToken({ refreshToken, getNodeUrl });
       return {
-        error: { message: 'Your session expired, but we have refreshed it. Please try again.', code: 500 }
+        error: {
+          message:
+            'Your session expired, but we have refreshed it. Please try again.',
+          code: 500,
+        },
       };
     }
 

--- a/app/src/api/dataSource/ClientApiDataSource.ts
+++ b/app/src/api/dataSource/ClientApiDataSource.ts
@@ -25,24 +25,33 @@ export function getJsonRpcClient() {
   );
 }
 
+function getConfigAndJwt() {
+  const jwtObject: JsonWebToken = getJWTObject();
+  const headers: AxiosHeader = createJwtHeader();
+  if (!jwtObject) {
+    return {
+      error: { message: 'Failed to get JWT token', code: 500 },
+    };
+  }
+  if (jwtObject.executor_public_key === null) {
+    return {
+      error: { message: 'Failed to get executor public key', code: 500 },
+    };
+  }
+
+  const config: RequestConfig = {
+    headers: headers,
+  };
+
+  return { jwtObject, config };
+}
+
 export class ClientApiDataSource implements ClientApi {
   async fetchFeed(params: FeedRequest): ApiResponse<Post[]> {
-    const jwtObject: JsonWebToken = getJWTObject();
-    const headers: AxiosHeader = createJwtHeader();
-    if (!jwtObject) {
-      return {
-        error: { message: 'Failed to get JWT token', code: 500 },
-      };
+    const { jwtObject, config, error } = getConfigAndJwt();
+    if (error) {
+      return { error };
     }
-    if (jwtObject.executor_public_key === null) {
-      return {
-        error: { message: 'Failed to get executor public key', code: 500 },
-      };
-    }
-
-    const config: RequestConfig = {
-      headers: headers,
-    };
 
     const response = await getJsonRpcClient().query<FeedRequest, Post[]>(
       {
@@ -53,10 +62,10 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
-    const error: RpcError | null = response?.error ?? null;
-    if (error && error.code) {
+    const rpcError: RpcError | null = response?.error ?? null;
+    if (rpcError && rpcError.code) {
       return {
-        error: await handleRpcError(error, getNodeUrl),
+        error: await handleRpcError(rpcError, getNodeUrl),
       };
     }
 
@@ -67,22 +76,10 @@ export class ClientApiDataSource implements ClientApi {
   }
 
   async fetchPost(params: PostRequest): ApiResponse<Post> {
-    const jwtObject: JsonWebToken = getJWTObject();
-    const headers: AxiosHeader = createJwtHeader();
-    if (!jwtObject) {
-      return {
-        error: { message: 'Failed to get JWT token', code: 500 },
-      };
+    const { jwtObject, config, error } = getConfigAndJwt();
+    if (error) {
+      return { error };
     }
-    if (jwtObject.executor_public_key === null) {
-      return {
-        error: { message: 'Failed to get executor public key', code: 500 },
-      };
-    }
-
-    const config: RequestConfig = {
-      headers: headers,
-    };
 
     const response = await getJsonRpcClient().query<PostRequest, Post>(
       {
@@ -93,10 +90,10 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
-    const error: RpcError | null = response?.error ?? null;
-    if (error && error.code) {
+    const rpcError: RpcError | null = response?.error ?? null;
+    if (rpcError && rpcError.code) {
       return {
-        error: await handleRpcError(error, getNodeUrl),
+        error: await handleRpcError(rpcError, getNodeUrl),
       };
     }
 
@@ -107,22 +104,10 @@ export class ClientApiDataSource implements ClientApi {
   }
 
   async createPost(params: CreatePostRequest): ApiResponse<Post> {
-    const jwtObject: JsonWebToken = getJWTObject();
-    const headers: AxiosHeader = createJwtHeader();
-    if (!jwtObject) {
-      return {
-        error: { message: 'Failed to get JWT token', code: 500 },
-      };
+    const { jwtObject, config, error } = getConfigAndJwt();
+    if (error) {
+      return { error };
     }
-    if (jwtObject.executor_public_key === null) {
-      return {
-        error: { message: 'Failed to get executor public key', code: 500 },
-      };
-    }
-
-    const config: RequestConfig = {
-      headers: headers,
-    };
 
     const response = await getJsonRpcClient().mutate<CreatePostRequest, Post>(
       {
@@ -133,10 +118,10 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
-    const error: RpcError | null = response?.error ?? null;
-    if (error && error.code) {
+    const rpcError: RpcError | null = response?.error ?? null;
+    if (rpcError && rpcError.code) {
       return {
-        error: await handleRpcError(error, getNodeUrl),
+        error: await handleRpcError(rpcError, getNodeUrl),
       };
     }
 
@@ -147,22 +132,10 @@ export class ClientApiDataSource implements ClientApi {
   }
 
   async createComment(params: CreateCommentRequest): ApiResponse<Comment> {
-    const jwtObject: JsonWebToken = getJWTObject();
-    const headers: AxiosHeader = createJwtHeader();
-    if (!jwtObject) {
-      return {
-        error: { message: 'Failed to get JWT token', code: 500 },
-      };
+    const { jwtObject, config, error } = getConfigAndJwt();
+    if (error) {
+      return { error };
     }
-    if (jwtObject.executor_public_key === null) {
-      return {
-        error: { message: 'Failed to get executor public key', code: 500 },
-      };
-    }
-
-    const config: RequestConfig = {
-      headers: headers,
-    };
 
     const response = await getJsonRpcClient().mutate<
       CreateCommentRequest,
@@ -176,10 +149,10 @@ export class ClientApiDataSource implements ClientApi {
       },
       config,
     );
-    const error: RpcError | null = response?.error ?? null;
-    if (error && error.code) {
+    const rpcError: RpcError | null = response?.error ?? null;
+    if (rpcError && rpcError.code) {
       return {
-        error: await handleRpcError(error, getNodeUrl),
+        error: await handleRpcError(rpcError, getNodeUrl),
       };
     }
 

--- a/app/src/components/header/header.tsx
+++ b/app/src/components/header/header.tsx
@@ -21,7 +21,7 @@ export default function Header() {
 
   useEffect(() => {
     const setExecutorPk = async () => {
-      let publicKey = getJWTObject().executor_public_key;
+      let publicKey = getJWTObject()?.executor_public_key;
       setExecutorPublicKey(publicKey);
     };
     if (accessToken) {

--- a/app/src/constants/en.global.json
+++ b/app/src/constants/en.global.json
@@ -1,6 +1,6 @@
 {
   "errorPopup": {
-    "dialogTitle": "Error: Failed to fetch data",
+    "dialogTitle": "Error",
     "reloadButtonText": "Reload the page"
   },
   "feedPage": {

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -3,11 +3,15 @@ import '../styles/tailwind.css';
 import type { AppProps } from 'next/app';
 import '@near-wallet-selector/modal-ui/styles.css';
 import WithIdAuth from '../components/auth/auth';
+import { AccessTokenWrapper } from '@calimero-is-near/calimero-p2p-sdk';
+import { getNodeUrl } from '../utils/node';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <WithIdAuth>
-      <Component {...pageProps} />
+      <AccessTokenWrapper getNodeUrl={getNodeUrl}>
+        <Component {...pageProps} />
+      </AccessTokenWrapper>
     </WithIdAuth>
   );
 }

--- a/app/src/pages/feed/index.tsx
+++ b/app/src/pages/feed/index.tsx
@@ -38,7 +38,7 @@ export default function FeedPage() {
   }, [fetchFeed]);
 
   const createPost = async (title: string, content: string) => {
-    setError("");
+    setError('');
     setLoading(true);
     const createPostRequest: CreatePostRequest = {
       title,

--- a/app/src/pages/feed/index.tsx
+++ b/app/src/pages/feed/index.tsx
@@ -15,13 +15,18 @@ export default function FeedPage() {
   const [loading, setLoading] = useState(true);
 
   const fetchFeed = useCallback(async (request: FeedRequest) => {
-    const response = await new ClientApiDataSource().fetchFeed(request);
-    if (response.error) {
-      setError(response.error.message);
+    try {
+      const response = await new ClientApiDataSource().fetchFeed(request);
+      if (response.error) {
+        setError(response.error.message);
+        setLoading(false);
+      }
+      setPosts(response?.data?.slice().reverse());
+      setLoading(false);
+    } catch (error) {
+      setError(error.message);
       setLoading(false);
     }
-    setPosts(response?.data?.slice().reverse());
-    setLoading(false);
   }, []);
 
   useEffect(() => {
@@ -33,6 +38,8 @@ export default function FeedPage() {
   }, [fetchFeed]);
 
   const createPost = async (title: string, content: string) => {
+    setError("");
+    setLoading(true);
     const createPostRequest: CreatePostRequest = {
       title,
       content,
@@ -42,11 +49,13 @@ export default function FeedPage() {
     );
     if (result.error) {
       setError(result.error.message);
+      setLoading(false);
+      setOpenCreatePost(false);
       return;
     }
 
     setOpenCreatePost(false);
-
+    setLoading(false);
     //TODO solve pagination
     const feedRequest: FeedRequest = {};
     fetchFeed({ feedRequest });


### PR DESCRIPTION
# feat: refresh JWT components and logic update

## Summary:
With update from SDK, components of the page are now wrapped in AccessTokenWrapper which checks the validity of JWT (if it expired) every 20 minutes or with each page refresh.
It will generate new token if token expired.

Regarding this application; when user is calling json-rpc with his webapp actions server checks token and if it returns that token has expired error message then it will call function from sdk to get new jwt token and notify user 
"Session has expired, but we have generated new token. try again".
